### PR TITLE
Use go-gl-legacy/gl package.

### DIFF
--- a/camera.go
+++ b/camera.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/boombuler/voxel/mgl"
-	"github.com/go-gl/gl"
-	glfw "github.com/go-gl/glfw3"
-	"github.com/go-gl/glu"
 	"math"
+
+	"github.com/boombuler/voxel/mgl"
+	"github.com/go-gl-legacy/gl"
+	"github.com/go-gl-legacy/glu"
+	"github.com/go-gl/glfw/v3.0/glfw"
 )
 
 type camera struct {

--- a/engine.go
+++ b/engine.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/boombuler/voxel/rendering"
-	"github.com/go-gl/gl"
-	glfw "github.com/go-gl/glfw3"
 	"runtime"
+
+	"github.com/boombuler/voxel/rendering"
+	"github.com/go-gl-legacy/gl"
+	"github.com/go-gl/glfw/v3.0/glfw"
 )
 
 type Options struct {

--- a/rendering/chunkrenderobj.go
+++ b/rendering/chunkrenderobj.go
@@ -1,7 +1,7 @@
 package rendering
 
 import (
-	"github.com/go-gl/gl"
+	"github.com/go-gl-legacy/gl"
 )
 
 func NewRenderedChunk(c Chunk, opt Options) Renderer {

--- a/rendering/frustumculling.go
+++ b/rendering/frustumculling.go
@@ -2,7 +2,7 @@ package rendering
 
 import (
 	"github.com/boombuler/voxel/mgl"
-	"github.com/go-gl/gl"
+	"github.com/go-gl-legacy/gl"
 )
 
 type plane struct {

--- a/rendering/meshbuffer.go
+++ b/rendering/meshbuffer.go
@@ -1,6 +1,6 @@
 package rendering
 
-import "github.com/go-gl/gl"
+import "github.com/go-gl-legacy/gl"
 
 type CubeMesh struct {
 	buf    gl.Buffer


### PR DESCRIPTION
Per the go-gl: Massive Overhaul
https://docs.google.com/document/d/1zORKEEFPsJ5AujtPbtQYQquvAopuXb3whWud1sA7nAE/edit?usp=sharing
go-gl/gl moved to go-gl-legacy/gl.

Before this change, the build failed. Now `go build .` succeeds. I have
not tested further than that.

To fix the build completely, a similar update to go-gl-legacy/glu https://github.com/go-gl-legacy/glu/pull/29 was also required.